### PR TITLE
Refactor CAC KeyStore utility for reuse by other applications

### DIFF
--- a/.github/coveragereport/badge_branchcoverage.svg
+++ b/.github/coveragereport/badge_branchcoverage.svg
@@ -101,7 +101,7 @@
         <text x="53" y="15" fill="#010101" fill-opacity=".3">Coverage</text>
         <text x="53" y="14" fill="#fff">Coverage</text>
         
-        <text class="" x="132.5" y="15" fill="#010101" fill-opacity=".3">77.9%</text><text class="" x="132.5" y="14">77.9%</text>
+        <text class="" x="132.5" y="15" fill="#010101" fill-opacity=".3">66.8%</text><text class="" x="132.5" y="14">66.8%</text>
         
     </g>
 

--- a/.github/coveragereport/badge_branchcoverage.svg
+++ b/.github/coveragereport/badge_branchcoverage.svg
@@ -101,7 +101,7 @@
         <text x="53" y="15" fill="#010101" fill-opacity=".3">Coverage</text>
         <text x="53" y="14" fill="#fff">Coverage</text>
         
-        <text class="" x="132.5" y="15" fill="#010101" fill-opacity=".3">66.8%</text><text class="" x="132.5" y="14">66.8%</text>
+        <text class="" x="132.5" y="15" fill="#010101" fill-opacity=".3">77.6%</text><text class="" x="132.5" y="14">77.6%</text>
         
     </g>
 

--- a/.github/coveragereport/badge_linecoverage.svg
+++ b/.github/coveragereport/badge_linecoverage.svg
@@ -100,7 +100,7 @@
 
         <text x="53" y="15" fill="#010101" fill-opacity=".3">Coverage</text>
         <text x="53" y="14" fill="#fff">Coverage</text>
-        <text class="" x="132.5" y="15" fill="#010101" fill-opacity=".3">93.1%</text><text class="" x="132.5" y="14">93.1%</text>
+        <text class="" x="132.5" y="15" fill="#010101" fill-opacity=".3">90.2%</text><text class="" x="132.5" y="14">90.2%</text>
         
         
     </g>

--- a/.github/coveragereport/badge_linecoverage.svg
+++ b/.github/coveragereport/badge_linecoverage.svg
@@ -100,7 +100,7 @@
 
         <text x="53" y="15" fill="#010101" fill-opacity=".3">Coverage</text>
         <text x="53" y="14" fill="#fff">Coverage</text>
-        <text class="" x="132.5" y="15" fill="#010101" fill-opacity=".3">90.2%</text><text class="" x="132.5" y="14">90.2%</text>
+        <text class="" x="132.5" y="15" fill="#010101" fill-opacity=".3">92.9%</text><text class="" x="132.5" y="14">92.9%</text>
         
         
     </g>

--- a/.github/coveragereport/badge_methodcoverage.svg
+++ b/.github/coveragereport/badge_methodcoverage.svg
@@ -102,7 +102,7 @@
         <text x="53" y="14" fill="#fff">Coverage</text>
         
         
-        <text class="" x="132.5" y="15" fill="#010101" fill-opacity=".3">92.4%</text><text class="" x="132.5" y="14">92.4%</text>
+        <text class="" x="132.5" y="15" fill="#010101" fill-opacity=".3">90.2%</text><text class="" x="132.5" y="14">90.2%</text>
     </g>
 
     <g>

--- a/.github/coveragereport/badge_methodcoverage.svg
+++ b/.github/coveragereport/badge_methodcoverage.svg
@@ -102,7 +102,7 @@
         <text x="53" y="14" fill="#fff">Coverage</text>
         
         
-        <text class="" x="132.5" y="15" fill="#010101" fill-opacity=".3">90.2%</text><text class="" x="132.5" y="14">90.2%</text>
+        <text class="" x="132.5" y="15" fill="#010101" fill-opacity=".3">92.1%</text><text class="" x="132.5" y="14">92.1%</text>
     </g>
 
     <g>

--- a/cwms-aaa-client/build.gradle
+++ b/cwms-aaa-client/build.gradle
@@ -11,14 +11,6 @@ dependencies {
     testRuntimeOnly(libs.junit.engine)
 }
 
-jacocoTestReport {
-    afterEvaluate {
-        classDirectories.setFrom(files(classDirectories.files.collect {
-            fileTree(dir: it, exclude: 'mil/army/usace/hec/cwms/aaa/client/Cac*')
-        }))
-    }
-}
-
 publishing {
     publications {
         maven(MavenPublication) {

--- a/cwms-aaa-client/build.gradle
+++ b/cwms-aaa-client/build.gradle
@@ -4,12 +4,11 @@ plugins {
 
 dependencies {
     api(project(":cwms-http-client"))
-    implementation("org.bouncycastle:bcpkix-jdk15on:1.70")
-    implementation('com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.0')
+    implementation(libs.jackson.jsr310)
 
     testImplementation(testFixtures(project(":cwms-http-client")))
-    testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.1")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.8.1")
+    testImplementation(libs.junit.api)
+    testRuntimeOnly(libs.junit.engine)
 }
 
 jacocoTestReport {

--- a/cwms-aaa-client/src/test/java/mil/army/usace/hec/cwms/aaa/client/CacEncryptedToken.java
+++ b/cwms-aaa-client/src/test/java/mil/army/usace/hec/cwms/aaa/client/CacEncryptedToken.java
@@ -51,7 +51,7 @@ final class CacEncryptedToken {
     @Test
     public void testCacEncryptedToken() throws Exception {
         String unencryptedToken = "8AAF8621FD4748C050814BE6D6AFDAFC";
-        X509KeyManager keyManager = (X509KeyManager) CacKeyManagerUtil.getKeyManager();
+        X509KeyManager keyManager = (X509KeyManager) CacKeyManagerUtil.createKeyManager();
         String[] aliases = keyManager.getClientAliases("RSA", null);
         String encryptionAlias = Arrays.stream(aliases)
             .filter(a -> a.toLowerCase().contains("encryption"))

--- a/cwms-aaa-client/src/test/java/mil/army/usace/hec/cwms/aaa/client/CacEncryptedToken.java
+++ b/cwms-aaa-client/src/test/java/mil/army/usace/hec/cwms/aaa/client/CacEncryptedToken.java
@@ -24,8 +24,15 @@
 
 package mil.army.usace.hec.cwms.aaa.client;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import mil.army.usace.hec.cwms.http.client.auth.CacKeyManagerUtil;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+import javax.net.ssl.X509KeyManager;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
@@ -35,13 +42,8 @@ import java.security.interfaces.RSAKey;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import javax.crypto.BadPaddingException;
-import javax.crypto.Cipher;
-import javax.crypto.IllegalBlockSizeException;
-import javax.crypto.NoSuchPaddingException;
-import javax.net.ssl.X509KeyManager;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 final class CacEncryptedToken {
 

--- a/cwms-aaa-client/src/test/java/mil/army/usace/hec/cwms/aaa/client/CacKeyManagerTest.java
+++ b/cwms-aaa-client/src/test/java/mil/army/usace/hec/cwms/aaa/client/CacKeyManagerTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022 Hydrologic Engineering Center
+ * Copyright (c) 2023 Hydrologic Engineering Center
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,10 +24,11 @@
 
 package mil.army.usace.hec.cwms.aaa.client;
 
+import mil.army.usace.hec.cwms.http.client.auth.CacKeyManager;
+import org.junit.jupiter.api.Test;
+
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import org.junit.jupiter.api.Test;
 
 final class CacKeyManagerTest {
 

--- a/cwms-aaa-client/src/test/java/mil/army/usace/hec/cwms/aaa/client/CwmsAAALoginTest.java
+++ b/cwms-aaa-client/src/test/java/mil/army/usace/hec/cwms/aaa/client/CwmsAAALoginTest.java
@@ -30,6 +30,9 @@ import mil.army.usace.hec.cwms.http.client.CookieJarFactory;
 import mil.army.usace.hec.cwms.http.client.HttpCookie;
 import mil.army.usace.hec.cwms.http.client.MockHttpServer;
 import mil.army.usace.hec.cwms.http.client.SslSocketData;
+import mil.army.usace.hec.cwms.http.client.auth.CacCertificateException;
+import mil.army.usace.hec.cwms.http.client.auth.CacKeyManager;
+import mil.army.usace.hec.cwms.http.client.auth.CacKeyManagerUtil;
 import org.junit.jupiter.api.Test;
 
 import javax.net.ssl.KeyManager;

--- a/cwms-aaa-client/src/test/java/mil/army/usace/hec/cwms/aaa/client/CwmsAAALoginTest.java
+++ b/cwms-aaa-client/src/test/java/mil/army/usace/hec/cwms/aaa/client/CwmsAAALoginTest.java
@@ -118,7 +118,7 @@ final class CwmsAAALoginTest {
                 .withSslSocketData(new SslSocketData(socketFactory, (X509TrustManager) trustManagerFactory.getTrustManagers()[0]))
                 .build();
         } else {
-            KeyManager keyManager = CacKeyManagerUtil.getKeyManager();
+            KeyManager keyManager = CacKeyManagerUtil.createKeyManager();
             sc.init(new KeyManager[] {keyManager}, trustManagerFactory.getTrustManagers(), null);
             SSLSocketFactory socketFactory = sc.getSocketFactory();
             apiConnectionInfo = new ApiConnectionInfoBuilder(TOMCAT_SERVER + "/CWMSLogin/")

--- a/cwms-aaa-client/src/test/java/mil/army/usace/hec/cwms/aaa/client/CwmsAAALogoutTest.java
+++ b/cwms-aaa-client/src/test/java/mil/army/usace/hec/cwms/aaa/client/CwmsAAALogoutTest.java
@@ -90,7 +90,7 @@ final class CwmsAAALogoutTest {
                 .withSslSocketData(new SslSocketData(socketFactory, (X509TrustManager) trustManagers[0]))
                 .build();
         } else {
-            KeyManager keyManager = CacKeyManagerUtil.getKeyManager();
+            KeyManager keyManager = CacKeyManagerUtil.createKeyManager();
             TrustManager[] trustManagers = trustManagerFactory.getTrustManagers();
             sc.init(new KeyManager[] {keyManager}, trustManagers, null);
             SSLSocketFactory socketFactory = sc.getSocketFactory();

--- a/cwms-aaa-client/src/test/java/mil/army/usace/hec/cwms/aaa/client/CwmsAAALogoutTest.java
+++ b/cwms-aaa-client/src/test/java/mil/army/usace/hec/cwms/aaa/client/CwmsAAALogoutTest.java
@@ -29,6 +29,7 @@ import mil.army.usace.hec.cwms.http.client.ApiConnectionInfoBuilder;
 import mil.army.usace.hec.cwms.http.client.CookieJarFactory;
 import mil.army.usace.hec.cwms.http.client.MockHttpServer;
 import mil.army.usace.hec.cwms.http.client.SslSocketData;
+import mil.army.usace.hec.cwms.http.client.auth.CacKeyManagerUtil;
 import org.junit.jupiter.api.Test;
 
 import javax.net.ssl.KeyManager;

--- a/cwms-aaa-client/src/test/java/mil/army/usace/hec/cwms/aaa/client/CwmsAAALogoutTest.java
+++ b/cwms-aaa-client/src/test/java/mil/army/usace/hec/cwms/aaa/client/CwmsAAALogoutTest.java
@@ -30,6 +30,7 @@ import mil.army.usace.hec.cwms.http.client.CookieJarFactory;
 import mil.army.usace.hec.cwms.http.client.MockHttpServer;
 import mil.army.usace.hec.cwms.http.client.SslSocketData;
 import mil.army.usace.hec.cwms.http.client.auth.CacKeyManagerUtil;
+import mil.army.usace.hec.cwms.http.client.auth.KeyManagerTestUtil;
 import org.junit.jupiter.api.Test;
 
 import javax.net.ssl.KeyManager;
@@ -48,7 +49,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import static mil.army.usace.hec.cwms.aaa.client.CwmsAAALoginTest.TOMCAT_SERVER;
-import static mil.army.usace.hec.cwms.aaa.client.CwmsAAALoginTest.getKeyManagerFromJreKeyStore;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 final class CwmsAAALogoutTest {
@@ -81,7 +81,7 @@ final class CwmsAAALogoutTest {
             mockHttpServer.enqueue(collect);
             mockHttpServer.start();
             String baseUrl = String.format("http://localhost:%s", mockHttpServer.getPort());
-            KeyManager keyManager = getKeyManagerFromJreKeyStore();
+            KeyManager keyManager = KeyManagerTestUtil.getKeyManagerFromJreKeyStore();
             TrustManager[] trustManagers = trustManagerFactory.getTrustManagers();
             sc.init(new KeyManager[] {keyManager}, trustManagers, null);
             SSLSocketFactory socketFactory = sc.getSocketFactory();

--- a/cwms-http-client/build.gradle
+++ b/cwms-http-client/build.gradle
@@ -68,7 +68,8 @@ jacocoTestReport {
     afterEvaluate {
         classDirectories.setFrom(files(classDirectories.files.collect {
             fileTree(dir: it, exclude: ['mil/army/usace/hec/cwms/http/client/CwmsHttpMetricsServiceProvider*',
-                                        'mil/army/usace/hec/cwms/http/client/Http2Util'])
+                                        'mil/army/usace/hec/cwms/http/client/Http2Util',
+                                        'mil/army/usace/hec/cwms/http/client/auth/Cac*'])
         }))
     }
 }

--- a/cwms-http-client/build.gradle
+++ b/cwms-http-client/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     implementation(libs.lookup)
     implementation(libs.jackson.jsr310)
     implementation(libs.jwt)
+    implementation(libs.bctls)
 
     runtimeOnly(libs.metrics.codahale)
     annotationProcessor(libs.service.annotations)

--- a/cwms-http-client/build.gradle
+++ b/cwms-http-client/build.gradle
@@ -27,29 +27,26 @@ plugins {
 }
 
 dependencies {
-    implementation(platform("com.squareup.okhttp3:okhttp-bom:4.9.2"))
-    implementation("com.squareup.okhttp3:okhttp:4.9.2")
-    implementation("com.squareup.okhttp3:okhttp-urlconnection:4.9.2")
-    implementation("com.squareup.okhttp3:logging-interceptor:4.9.2")
-    implementation('mil.army.usace.hec:metrics-services:2.0')
-    implementation('mil.army.usace.hec:lookup:1.0')
-    implementation('org.bouncycastle:bctls-jdk15on:1.63')
-    implementation('com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.0')
-    implementation('javax.annotation:javax.annotation-api:1.3.2')
-    implementation("com.auth0:java-jwt:4.0.0")
+    implementation(platform(libs.okhttp.bom))
+    implementation(libs.okhttp)
+    implementation(libs.okhttp.urlconnection)
+    implementation(libs.okhttp.logging)
+    implementation(libs.metrics)
+    implementation(libs.lookup)
+    implementation(libs.jackson.jsr310)
+    implementation(libs.jwt)
 
-    runtimeOnly('mil.army.usace.hec:metrics-codahale:2.0')
-    annotationProcessor('mil.army.usace.hec:service-annotations:1.2.1')
+    runtimeOnly(libs.metrics.codahale)
+    annotationProcessor(libs.service.annotations)
 
-    testImplementation('org.junit.jupiter:junit-jupiter-api:5.8.1')
-    testImplementation(platform("com.squareup.okhttp3:okhttp-bom:4.9.2"))
-    testImplementation('com.squareup.okhttp3:okhttp:4.9.2')
-    testImplementation('com.squareup.okhttp3:mockwebserver:4.9.2')
-    testRuntimeOnly('org.junit.jupiter:junit-jupiter-engine:5.8.1')
+    testImplementation(libs.junit.api)
+    testImplementation(platform(libs.okhttp.bom))
+    testImplementation(libs.okhttp.mockwebserver)
+    testRuntimeOnly(libs.junit.engine)
 
-    testFixturesImplementation(platform("com.squareup.okhttp3:okhttp-bom:4.9.2"))
-    testFixturesImplementation('com.squareup.okhttp3:okhttp:4.9.2')
-    testFixturesImplementation('com.squareup.okhttp3:mockwebserver:4.9.2')
+    testFixturesImplementation(platform(libs.okhttp.bom))
+    testFixturesImplementation(libs.okhttp)
+    testFixturesImplementation(libs.okhttp.mockwebserver)
 }
 
 publishing {

--- a/cwms-http-client/src/main/java/mil/army/usace/hec/cwms/http/client/ApiConnectionInfo.java
+++ b/cwms-http-client/src/main/java/mil/army/usace/hec/cwms/http/client/ApiConnectionInfo.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022 Hydrologic Engineering Center
+ * Copyright (c) 2023 Hydrologic Engineering Center
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,11 +24,13 @@
 
 package mil.army.usace.hec.cwms.http.client;
 
-import java.util.List;
-import java.util.Optional;
 import okhttp3.Authenticator;
 import okhttp3.CookieJar;
 import okhttp3.Interceptor;
+
+import javax.net.ssl.HostnameVerifier;
+import java.util.List;
+import java.util.Optional;
 
 public final class ApiConnectionInfo {
 
@@ -37,14 +39,16 @@ public final class ApiConnectionInfo {
     private final CookieJar cookieJar;
     private final List<Interceptor> interceptors;
     private final Authenticator authenticator;
+    private final HostnameVerifier hostnameVerifier;
 
     ApiConnectionInfo(String apiRoot, SslSocketData sslSocketData, CookieJar cookieJar,
-                      List<Interceptor> interceptors, Authenticator authenticator) {
+                      List<Interceptor> interceptors, Authenticator authenticator, HostnameVerifier hostnameVerifier) {
         this.apiRoot = apiRoot;
         this.sslSocketData = sslSocketData;
         this.interceptors = interceptors;
         this.authenticator = authenticator;
         this.cookieJar = cookieJar;
+        this.hostnameVerifier = hostnameVerifier;
     }
 
     public String getApiRoot() {
@@ -65,5 +69,9 @@ public final class ApiConnectionInfo {
 
     Optional<CookieJar> cookieJar() {
         return Optional.ofNullable(cookieJar);
+    }
+
+    Optional<HostnameVerifier> hostnameVerifier() {
+        return Optional.ofNullable(hostnameVerifier);
     }
 }

--- a/cwms-http-client/src/main/java/mil/army/usace/hec/cwms/http/client/ApiConnectionInfoBuilder.java
+++ b/cwms-http-client/src/main/java/mil/army/usace/hec/cwms/http/client/ApiConnectionInfoBuilder.java
@@ -24,13 +24,15 @@
 
 package mil.army.usace.hec.cwms.http.client;
 
-import java.util.ArrayList;
-import java.util.List;
 import mil.army.usace.hec.cwms.http.client.auth.OAuth2TokenProvider;
 import mil.army.usace.hec.cwms.http.client.auth.SimpleAuthKeyProvider;
 import okhttp3.Authenticator;
 import okhttp3.CookieJar;
 import okhttp3.Interceptor;
+
+import javax.net.ssl.HostnameVerifier;
+import java.util.ArrayList;
+import java.util.List;
 
 public class ApiConnectionInfoBuilder {
 
@@ -41,6 +43,7 @@ public class ApiConnectionInfoBuilder {
     private CookieJarFactory.CookieJarSupplier cookieJarSupplier;
     private CookieAuthenticator cookieAuthenticator;
     private SimpleAuthKeyProvider simpleAuthKeyProvider;
+    private HostnameVerifier hostnameVerifier;
 
     public ApiConnectionInfoBuilder(String apiRoot) {
         this.apiRoot = apiRoot;
@@ -68,6 +71,11 @@ public class ApiConnectionInfoBuilder {
 
     public ApiConnectionInfoBuilder withAuthorizationKeyProvider(SimpleAuthKeyProvider simpleAuthKeyProvider) {
         this.simpleAuthKeyProvider = simpleAuthKeyProvider;
+        return this;
+    }
+
+    public ApiConnectionInfoBuilder withHostnameVerifier(HostnameVerifier hostnameVerifier) {
+        this.hostnameVerifier = hostnameVerifier;
         return this;
     }
 
@@ -101,6 +109,6 @@ public class ApiConnectionInfoBuilder {
             }
             authenticator = cookieAuthenticator;
         }
-        return new ApiConnectionInfo(apiRoot, sslSocketData, cookieJar, interceptors, authenticator);
+        return new ApiConnectionInfo(apiRoot, sslSocketData, cookieJar, interceptors, authenticator, hostnameVerifier);
     }
 }

--- a/cwms-http-client/src/main/java/mil/army/usace/hec/cwms/http/client/HttpRequestBuilderImpl.java
+++ b/cwms-http-client/src/main/java/mil/army/usace/hec/cwms/http/client/HttpRequestBuilderImpl.java
@@ -29,6 +29,7 @@ import mil.army.usace.hec.cwms.http.client.request.HttpPutRequest;
 import mil.army.usace.hec.cwms.http.client.request.HttpRequestExecutor;
 import mil.army.usace.hec.cwms.http.client.request.HttpRequestMediaType;
 import mil.army.usace.hec.cwms.http.client.request.HttpRequestMethod;
+import okhttp3.Headers;
 import okhttp3.HttpUrl;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
@@ -238,10 +239,11 @@ public class HttpRequestBuilderImpl implements HttpRequestBuilder {
                         throw new IOException("Error with request, body not returned for request: " + request);
                     }
                     Set<HttpCookie> cookies = client.cookieJar().loadForRequest(request.url())
-                        .stream()
-                        .map(OkHttpCookieWrapper::new)
-                        .collect(toSet());
-                    retVal = new HttpRequestResponse(responseBody, cookies);
+                            .stream()
+                            .map(OkHttpCookieWrapper::new)
+                            .collect(toSet());
+                    Headers headers = execute.headers();
+                    retVal = new HttpRequestResponse(responseBody, cookies, headers);
                 } else {
                     handleExecutionError(execute, request);
                 }

--- a/cwms-http-client/src/main/java/mil/army/usace/hec/cwms/http/client/HttpRequestBuilderImpl.java
+++ b/cwms-http-client/src/main/java/mil/army/usace/hec/cwms/http/client/HttpRequestBuilderImpl.java
@@ -24,8 +24,18 @@
 
 package mil.army.usace.hec.cwms.http.client;
 
-import mil.army.usace.hec.cwms.http.client.request.*;
-import okhttp3.*;
+import mil.army.usace.hec.cwms.http.client.request.HttpPostRequest;
+import mil.army.usace.hec.cwms.http.client.request.HttpPutRequest;
+import mil.army.usace.hec.cwms.http.client.request.HttpRequestExecutor;
+import mil.army.usace.hec.cwms.http.client.request.HttpRequestMediaType;
+import mil.army.usace.hec.cwms.http.client.request.HttpRequestMethod;
+import okhttp3.HttpUrl;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.jsse.provider.BouncyCastleJsseProvider;
 import usace.metrics.noop.NoOpTimer;
@@ -40,7 +50,11 @@ import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
 import java.security.Security;
 import java.security.SignatureException;
-import java.util.*;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.Set;
 
 import static java.util.stream.Collectors.toSet;
 import static mil.army.usace.hec.cwms.http.client.Http2Util.isHttp2NativelySupported;

--- a/cwms-http-client/src/main/java/mil/army/usace/hec/cwms/http/client/OkHttpClientFactory.java
+++ b/cwms-http-client/src/main/java/mil/army/usace/hec/cwms/http/client/OkHttpClientFactory.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022 Hydrologic Engineering Center
+ * Copyright (c) 2023 Hydrologic Engineering Center
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,11 +24,13 @@
 
 package mil.army.usace.hec.cwms.http.client;
 
-import java.util.List;
-import java.util.Optional;
 import okhttp3.CookieJar;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
+
+import javax.net.ssl.HostnameVerifier;
+import java.util.List;
+import java.util.Optional;
 
 final class OkHttpClientFactory {
 
@@ -49,6 +51,10 @@ final class OkHttpClientFactory {
         }
         builder = apiConnectionInfo.authenticator().map(builder::authenticator).orElse(builder);
         CookieJar cookieJar = apiConnectionInfo.cookieJar().orElse(CookieJar.NO_COOKIES);
+        Optional<HostnameVerifier> hostnameVerifier = apiConnectionInfo.hostnameVerifier();
+        if (hostnameVerifier.isPresent()) {
+            builder.hostnameVerifier(hostnameVerifier.get());
+        }
         return builder.cookieJar(cookieJar).build();
     }
 }

--- a/cwms-http-client/src/main/java/mil/army/usace/hec/cwms/http/client/auth/CacCertificateException.java
+++ b/cwms-http-client/src/main/java/mil/army/usace/hec/cwms/http/client/auth/CacCertificateException.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022 Hydrologic Engineering Center
+ * Copyright (c) 2023 Hydrologic Engineering Center
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-package mil.army.usace.hec.cwms.aaa.client;
+package mil.army.usace.hec.cwms.http.client.auth;
 
 public final class CacCertificateException extends Exception {
 

--- a/cwms-http-client/src/main/java/mil/army/usace/hec/cwms/http/client/auth/CacKeyManager.java
+++ b/cwms-http-client/src/main/java/mil/army/usace/hec/cwms/http/client/auth/CacKeyManager.java
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-package mil.army.usace.hec.cwms.aaa.client;
+package mil.army.usace.hec.cwms.http.client.auth;
 
 import javax.net.ssl.X509KeyManager;
 import java.net.Socket;

--- a/cwms-http-client/src/main/java/mil/army/usace/hec/cwms/http/client/auth/CacKeyManagerUtil.java
+++ b/cwms-http-client/src/main/java/mil/army/usace/hec/cwms/http/client/auth/CacKeyManagerUtil.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022 Hydrologic Engineering Center
+ * Copyright (c) 2023 Hydrologic Engineering Center
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,17 +22,17 @@
  * SOFTWARE.
  */
 
-package mil.army.usace.hec.cwms.aaa.client;
+package mil.army.usace.hec.cwms.http.client.auth;
 
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.X509KeyManager;
 import java.io.IOException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
-import javax.net.ssl.KeyManager;
-import javax.net.ssl.KeyManagerFactory;
-import javax.net.ssl.X509KeyManager;
 
 
 public final class CacKeyManagerUtil {

--- a/cwms-http-client/src/main/java/mil/army/usace/hec/cwms/http/client/auth/CacKeyManagerUtil.java
+++ b/cwms-http-client/src/main/java/mil/army/usace/hec/cwms/http/client/auth/CacKeyManagerUtil.java
@@ -36,17 +36,20 @@ import java.security.cert.CertificateException;
 
 
 public final class CacKeyManagerUtil {
-    private static KeyManager instance;
 
     private CacKeyManagerUtil() {
         throw new AssertionError("Utility class");
     }
 
-    private static KeyManager createKeyManager() throws CacCertificateException {
-        return getKeyManagerFromWindowsKeyStore();
+    public static KeyManager createKeyManager() throws CacCertificateException {
+        return getKeyManagerFromWindowsKeyStore(null);
     }
 
-    private static CacKeyManager getKeyManagerFromWindowsKeyStore() throws CacCertificateException {
+    public static KeyManager createKeyManager(String certificateAlias) throws CacCertificateException {
+        return getKeyManagerFromWindowsKeyStore(certificateAlias);
+    }
+
+    private static CacKeyManager getKeyManagerFromWindowsKeyStore(String certificateAlias) throws CacCertificateException {
         try {
             KeyStore keystore = KeyStore.getInstance("WINDOWS-MY");
             keystore.load(null, null);
@@ -55,20 +58,13 @@ public final class CacKeyManagerUtil {
             KeyManager[] kms = kmf.getKeyManagers();
             for (KeyManager km : kms) {
                 if (km instanceof X509KeyManager) {
-                    return new CacKeyManager((X509KeyManager) km, keystore);
+                    return new CacKeyManager((X509KeyManager) km, keystore, certificateAlias);
                 }
             }
             throw new CacCertificateException("Failed to get X509KeyManager from Windows OS");
         } catch (KeyStoreException | UnrecoverableKeyException | NoSuchAlgorithmException | IOException | CertificateException e) {
             throw new CacCertificateException("Failed to get X509KeyManager from Windows OS", e);
         }
-    }
-
-    public static synchronized KeyManager getKeyManager() throws CacCertificateException {
-        if (instance == null) {
-            instance = createKeyManager();
-        }
-        return instance;
     }
 
 }

--- a/cwms-http-client/src/main/java/mil/army/usace/hec/cwms/http/client/auth/CacKeyManagerUtil.java
+++ b/cwms-http-client/src/main/java/mil/army/usace/hec/cwms/http/client/auth/CacKeyManagerUtil.java
@@ -48,7 +48,7 @@ import java.util.regex.Pattern;
 
 
 public final class CacKeyManagerUtil {
-    static final Pattern EDIPI_PATTERN = Pattern.compile("\\d{16}@mil", Pattern.CASE_INSENSITIVE);
+    static final Pattern EDIPI_PATTERN = Pattern.compile("\\d{10}@", Pattern.CASE_INSENSITIVE);
     private static final Logger LOGGER = Logger.getLogger(CacKeyManagerUtil.class.getName());
 
     private CacKeyManagerUtil() {
@@ -115,9 +115,13 @@ public final class CacKeyManagerUtil {
                 Object bytes = subjectAlternativeName.get(1);
                 if (bytes instanceof byte[]) {
                     String encoded = new String((byte[]) bytes);
+                    int edipiLengh = 10;
                     int index = encoded.indexOf("@mil");
-                    if (index >= 16) {
-                        String edipiSan = encoded.substring(index - 16, index + 4);
+                    if (index < edipiLengh) {
+                        index = encoded.indexOf("@rma");
+                    }
+                    if (index >= edipiLengh) {
+                        String edipiSan = encoded.substring(index - edipiLengh, index + 1);
                         if (EDIPI_PATTERN.matcher(edipiSan).matches()) {
                             return true;
                         }

--- a/cwms-http-client/src/test/java/mil/army/usace/hec/cwms/http/client/SimpleAuthHeaderAuthenticatorTest.java
+++ b/cwms-http-client/src/test/java/mil/army/usace/hec/cwms/http/client/SimpleAuthHeaderAuthenticatorTest.java
@@ -25,7 +25,11 @@
 package mil.army.usace.hec.cwms.http.client;
 
 import mil.army.usace.hec.cwms.http.client.auth.SimpleAuthKeyProvider;
-import okhttp3.*;
+import okhttp3.MediaType;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.jupiter.api.Test;
@@ -76,7 +80,7 @@ class SimpleAuthHeaderAuthenticatorTest {
             SimpleAuthKeyProvider tokenProvider = () -> "Bearer " + ACCESS_TOKEN;
             SimpleAuthHeaderAuthenticator authenticator = new SimpleAuthHeaderAuthenticator(tokenProvider);
             assertThrows(UnauthorizedException.class, () -> new HttpRequestBuilderImpl(new ApiConnectionInfo(String.format("http://localhost:%s", mockWebServer.getPort()), null,
-                    null, new ArrayList<>(), authenticator))
+                    null, new ArrayList<>(), authenticator, null))
                     .post()
                     .withBody("")
                     .withMediaType("application/json")

--- a/cwms-http-client/src/test/java/mil/army/usace/hec/cwms/http/client/TestHttpRequestResponse.java
+++ b/cwms-http-client/src/test/java/mil/army/usace/hec/cwms/http/client/TestHttpRequestResponse.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022 Hydrologic Engineering Center
+ * Copyright (c) 2023 Hydrologic Engineering Center
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,7 +24,9 @@
 
 package mil.army.usace.hec.cwms.http.client;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import okhttp3.MediaType;
+import okhttp3.ResponseBody;
+import org.junit.jupiter.api.Test;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -32,9 +34,8 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.Collections;
 import java.util.stream.Collectors;
-import okhttp3.MediaType;
-import okhttp3.ResponseBody;
-import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class TestHttpRequestResponse {
 
@@ -43,7 +44,7 @@ class TestHttpRequestResponse {
         String bodyStr =
             "{\"message\":\"Unable to find category based on parameters given\",\"incidentIdentifier\":\"-49092149940938\",\"details\":{}}";
         ResponseBody body = ResponseBody.create(bodyStr, MediaType.parse("application/json"));
-        HttpRequestResponse httpRequestResponse = new HttpRequestResponse(body, Collections.emptySet());
+        HttpRequestResponse httpRequestResponse = new HttpRequestResponse(body, Collections.emptySet(), null);
         assertEquals(bodyStr, httpRequestResponse.getBody());
     }
 
@@ -52,7 +53,7 @@ class TestHttpRequestResponse {
         String bodyStr = "Hello World";
         byte[] bytes = bodyStr.getBytes();
         ResponseBody body = ResponseBody.create(bytes, MediaType.parse("text/plain"));
-        HttpRequestResponse httpRequestResponse = new HttpRequestResponse(body, Collections.emptySet());
+        HttpRequestResponse httpRequestResponse = new HttpRequestResponse(body, Collections.emptySet(), null);
         try (InputStream inputStream = httpRequestResponse.getStream()) {
             String result = new BufferedReader(new InputStreamReader(inputStream))
                 .lines().collect(Collectors.joining("\n"));

--- a/cwms-http-client/src/test/java/mil/army/usace/hec/cwms/http/client/TestOkHttpClientInstance.java
+++ b/cwms-http-client/src/test/java/mil/army/usace/hec/cwms/http/client/TestOkHttpClientInstance.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022 Hydrologic Engineering Center
+ * Copyright (c) 2023 Hydrologic Engineering Center
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,7 +24,9 @@
 
 package mil.army.usace.hec.cwms.http.client;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import okhttp3.OkHttpClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -32,16 +34,15 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import okhttp3.OkHttpClient;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class TestOkHttpClientInstance {
 
     @BeforeEach
-    private void resetSingleton() throws Exception {
+    void resetSingleton() throws Exception {
         Arrays.stream(Logger.getLogger(OkHttpClientInstance.class.getName()).getHandlers())
-              .forEach(h -> h.setLevel(Level.FINEST));
+                .forEach(h -> h.setLevel(Level.FINEST));
         Logger.getLogger(OkHttpClientInstance.class.getName()).setLevel(Level.FINEST);
         Field field = OkHttpClientInstance.class.getDeclaredField("INSTANCE");
         field.setAccessible(true);

--- a/cwms-http-client/src/test/java/mil/army/usace/hec/cwms/http/client/auth/CacKeyManagerTest.java
+++ b/cwms-http-client/src/test/java/mil/army/usace/hec/cwms/http/client/auth/CacKeyManagerTest.java
@@ -22,9 +22,8 @@
  * SOFTWARE.
  */
 
-package mil.army.usace.hec.cwms.aaa.client;
+package mil.army.usace.hec.cwms.http.client.auth;
 
-import mil.army.usace.hec.cwms.http.client.auth.CacKeyManager;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/cwms-http-client/src/test/java/mil/army/usace/hec/cwms/http/client/auth/CacKeyManagerUtilTest.java
+++ b/cwms-http-client/src/test/java/mil/army/usace/hec/cwms/http/client/auth/CacKeyManagerUtilTest.java
@@ -29,13 +29,13 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-final class CacKeyManagerTest {
+final class CacKeyManagerUtilTest {
 
     @Test
     void testPivEdipiPattern() {
-        assertTrue(CacKeyManager.EDIPI_PATTERN.matcher("1234567890123456@mil").matches());
-        assertTrue(CacKeyManager.EDIPI_PATTERN.matcher("1234567890123456@MIL").matches());
-        assertFalse(CacKeyManager.EDIPI_PATTERN.matcher("1234567890123456@ARMY").matches());
-        assertFalse(CacKeyManager.EDIPI_PATTERN.matcher("234567890123456@mil").matches());
+        assertTrue(CacKeyManagerUtil.EDIPI_PATTERN.matcher("1234567890123456@mil").matches());
+        assertTrue(CacKeyManagerUtil.EDIPI_PATTERN.matcher("1234567890123456@MIL").matches());
+        assertFalse(CacKeyManagerUtil.EDIPI_PATTERN.matcher("1234567890123456@ARMY").matches());
+        assertFalse(CacKeyManagerUtil.EDIPI_PATTERN.matcher("234567890123456@mil").matches());
     }
 }

--- a/cwms-http-client/src/test/java/mil/army/usace/hec/cwms/http/client/auth/CacKeyManagerUtilTest.java
+++ b/cwms-http-client/src/test/java/mil/army/usace/hec/cwms/http/client/auth/CacKeyManagerUtilTest.java
@@ -33,9 +33,8 @@ final class CacKeyManagerUtilTest {
 
     @Test
     void testPivEdipiPattern() {
-        assertTrue(CacKeyManagerUtil.EDIPI_PATTERN.matcher("1234567890123456@mil").matches());
-        assertTrue(CacKeyManagerUtil.EDIPI_PATTERN.matcher("1234567890123456@MIL").matches());
-        assertFalse(CacKeyManagerUtil.EDIPI_PATTERN.matcher("1234567890123456@ARMY").matches());
-        assertFalse(CacKeyManagerUtil.EDIPI_PATTERN.matcher("234567890123456@mil").matches());
+        assertTrue(CacKeyManagerUtil.EDIPI_PATTERN.matcher("1234567890@").matches());
+        assertTrue(CacKeyManagerUtil.EDIPI_PATTERN.matcher("1234567890@").matches());
+        assertFalse(CacKeyManagerUtil.EDIPI_PATTERN.matcher("123456@").matches());
     }
 }

--- a/cwms-http-client/src/testFixtures/java/mil/army/usace/hec/cwms/http/client/auth/KeyManagerTestUtil.java
+++ b/cwms-http-client/src/testFixtures/java/mil/army/usace/hec/cwms/http/client/auth/KeyManagerTestUtil.java
@@ -1,0 +1,58 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 Hydrologic Engineering Center
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package mil.army.usace.hec.cwms.http.client.auth;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.X509KeyManager;
+import java.io.IOException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
+
+public final class KeyManagerTestUtil {
+
+    public static CacKeyManager getKeyManagerFromJreKeyStore() throws CacCertificateException {
+        String defaultType = KeyStore.getDefaultType();
+        try {
+            KeyStore keystore = KeyStore.getInstance(defaultType);
+            keystore.load(null, null);
+            KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+            kmf.init(keystore, null);
+            KeyManager[] kms = kmf.getKeyManagers();
+            for (KeyManager km : kms) {
+                if (km instanceof X509KeyManager) {
+                    return new CacKeyManager((X509KeyManager) km, keystore);
+                }
+            }
+            throw new CacCertificateException("Failed to get X509KeyManager from type: " + defaultType);
+        } catch (KeyStoreException | UnrecoverableKeyException | NoSuchAlgorithmException | IOException |
+                 CertificateException e) {
+            throw new CacCertificateException("Failed to get X509KeyManager from type: " + defaultType, e);
+        }
+    }
+}

--- a/cwms-http-client/src/testFixtures/java/mil/army/usace/hec/cwms/http/client/auth/KeyManagerTestUtil.java
+++ b/cwms-http-client/src/testFixtures/java/mil/army/usace/hec/cwms/http/client/auth/KeyManagerTestUtil.java
@@ -46,7 +46,7 @@ public final class KeyManagerTestUtil {
             KeyManager[] kms = kmf.getKeyManagers();
             for (KeyManager km : kms) {
                 if (km instanceof X509KeyManager) {
-                    return new CacKeyManager((X509KeyManager) km, keystore);
+                    return new CacKeyManager((X509KeyManager) km, keystore, null);
                 }
             }
             throw new CacCertificateException("Failed to get X509KeyManager from type: " + defaultType);

--- a/cwms-radar-client/build.gradle
+++ b/cwms-radar-client/build.gradle
@@ -8,8 +8,8 @@ dependencies {
 
     testImplementation(testFixtures(project(":cwms-http-client")))
     testImplementation(project(":cwms-aaa-client"))
-    testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.1")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.8.1")
+    testImplementation(libs.junit.api)
+    testRuntimeOnly(libs.junit.engine)
 }
 
 

--- a/cwms-radar-client/src/test/java/mil/army/usace/hec/cwms/radar/client/controllers/TestController.java
+++ b/cwms-radar-client/src/test/java/mil/army/usace/hec/cwms/radar/client/controllers/TestController.java
@@ -24,20 +24,6 @@
 
 package mil.army.usace.hec.cwms.radar.client.controllers;
 
-import java.io.File;
-import java.io.IOException;
-import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.security.KeyStore;
-import java.util.prefs.Preferences;
-import javax.net.ssl.KeyManager;
-import javax.net.ssl.KeyManagerFactory;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLSocketFactory;
-import javax.net.ssl.TrustManagerFactory;
-import javax.net.ssl.X509TrustManager;
-import mil.army.usace.hec.cwms.aaa.client.CacKeyManagerUtil;
 import mil.army.usace.hec.cwms.aaa.client.CwmsAuthCookieCallback;
 import mil.army.usace.hec.cwms.aaa.client.CwmsLoginController;
 import mil.army.usace.hec.cwms.http.client.ApiConnectionInfo;
@@ -47,9 +33,24 @@ import mil.army.usace.hec.cwms.http.client.CookieJarFactory;
 import mil.army.usace.hec.cwms.http.client.MockHttpServer;
 import mil.army.usace.hec.cwms.http.client.PreferencesBackedCookieStore;
 import mil.army.usace.hec.cwms.http.client.SslSocketData;
+import mil.army.usace.hec.cwms.http.client.auth.CacKeyManagerUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyStore;
+import java.util.prefs.Preferences;
 
 abstract class TestController {
 

--- a/cwms-radar-client/src/test/java/mil/army/usace/hec/cwms/radar/client/controllers/TestController.java
+++ b/cwms-radar-client/src/test/java/mil/army/usace/hec/cwms/radar/client/controllers/TestController.java
@@ -151,7 +151,7 @@ abstract class TestController {
             if(USE_MOCK) {
                 keyManager = getKeyManagerFromJreKeyStore();
             } else {
-                keyManager = CacKeyManagerUtil.getKeyManager();
+                keyManager = CacKeyManagerUtil.createKeyManager();
             }
             sc.init(new KeyManager[] {keyManager}, trustManagerFactory.getTrustManagers(), null);
             SSLSocketFactory socketFactory = sc.getSocketFactory();

--- a/cwms-radar-model/build.gradle
+++ b/cwms-radar-model/build.gradle
@@ -23,16 +23,17 @@
  */
 
 plugins {
+    id 'java-library'
     id 'org.hidetake.swagger.generator' version '2.18.2'
 }
 
 dependencies {
-    implementation('com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.0')
-    implementation('com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.13.0')
-    implementation('io.swagger:swagger-annotations:1.6.3')
-    implementation('javax.validation:validation-api:2.0.1.Final')
-    implementation('javax.annotation:javax.annotation-api:1.3.2')
-    swaggerCodegen('io.swagger.codegen.v3:swagger-codegen-cli:3.0.30')
+    implementation(libs.jackson.jsr310)
+    implementation(libs.jackson.xml)
+    implementation(libs.swagger.annotations)
+    implementation(libs.validation.api)
+    compileOnly(libs.annotation.api)
+    swaggerCodegen(libs.swagger.codegen)
 }
 
 publishing {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ okhttp = "4.11.0"
 bouncycastle = "1.75"
 
 #Test Dependencies
-junit = "5.9.1"
+junit = "5.9.3"
 
 [libraries]
 #HEC Dependencies

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,48 @@
+[versions]
+
+#HEC Dependencies
+metrics = "2.0"
+lookup = "1.1"
+service-annotations = "1.2.1"
+
+#Third Party Dependencies
+jackson = "2.13.0"
+swagger-annotations = "1.6.3"
+validation-api = "2.0.1.Final"
+annotation-api = "1.3.2"
+swagger-codegen = "3.0.30"
+jwt = "4.0.0"
+okhttp = "4.11.0"
+
+#Test Dependencies
+junit = "5.9.1"
+
+[libraries]
+#HEC Dependencies
+
+metrics = { module = "mil.army.usace.hec:metrics-services", version.ref = "metrics" }
+metrics-codahale = { module = "mil.army.usace.hec:metrics-codahale", version.ref = "metrics" }
+
+lookup = { module = "mil.army.usace.hec:lookup", version.ref = "lookup" }
+service-annotations = { module = "mil.army.usace.hec:service-annotations", version.ref = "service-annotations" }
+
+#Third-Party
+jackson-jsr310 = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jsr310", version.ref = "jackson" }
+jackson-xml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-xml", version.ref = "jackson" }
+swagger-annotations = { module = "io.swagger:swagger-annotations", version.ref = "swagger-annotations" }
+validation-api = { module = "javax.validation:validation-api", version.ref = "validation-api" }
+annotation-api = { module = "javax.annotation:javax.annotation-api", version.ref = "annotation-api" }
+swagger-codegen = { module = "io.swagger.codegen.v3:swagger-codegen-cli", version.ref = "swagger-codegen" }
+jwt = { module = "com.auth0:java-jwt", version.ref = "jwt" }
+okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
+okhttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp" }
+okhttp-urlconnection = { module = "com.squareup.okhttp3:okhttp-urlconnection", version.ref = "okhttp" }
+okhttp-logging = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }
+okhttp-bom = { module = "com.squareup.okhttp3:okhttp-bom", version.ref = "okhttp" }
+
+#Test Dependencies
+junit-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit" }
+junit-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit" }
+junit-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit" }
+
+

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ annotation-api = "1.3.2"
 swagger-codegen = "3.0.30"
 jwt = "4.0.0"
 okhttp = "4.11.0"
+bouncycastle = "1.75"
 
 #Test Dependencies
 junit = "5.9.1"
@@ -39,6 +40,7 @@ okhttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.
 okhttp-urlconnection = { module = "com.squareup.okhttp3:okhttp-urlconnection", version.ref = "okhttp" }
 okhttp-logging = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }
 okhttp-bom = { module = "com.squareup.okhttp3:okhttp-bom", version.ref = "okhttp" }
+bctls = { module = "org.bouncycastle:bctls-jdk18on", version.ref = "bouncycastle" }
 
 #Test Dependencies
 junit-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,29 @@
+#
+# MIT License
+#
+# Copyright (c) 2023 Hydrologic Engineering Center
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -1,19 +1,27 @@
 #!/usr/bin/env sh
 
 #
-# Copyright 2015 the original author or authors.
+# MIT License
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# Copyright (c) 2023 Hydrologic Engineering Center
 #
-#      https://www.apache.org/licenses/LICENSE-2.0
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
 #
 
 ##############################################################################


### PR DESCRIPTION
Cumulus uses and identical copy of the utility and CWMS Servers have a slightly modified version. Refactor these outside of the CWMS_AAA package for reuse.

Also remove dependency onto bouncy castle for reading the EDIPI Subject Alternative Name. This will pave the way forward for removing the dependency elsewhere.

Update to gradle 8 and version catalog while I'm changing dependencies.