### PR TITLE
add tests against CWMS National

### DIFF
--- a/cwms-http-client/src/test/java/mil/army/usace/hec/cwms/http/client/exploratory/CdaNationalTest.java
+++ b/cwms-http-client/src/test/java/mil/army/usace/hec/cwms/http/client/exploratory/CdaNationalTest.java
@@ -1,0 +1,80 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 Hydrologic Engineering Center
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package mil.army.usace.hec.cwms.http.client.exploratory;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.junit.jupiter.api.Test;
+
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URL;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ *
+ */
+final class CdaNationalTest {
+
+    @Test
+    void testNationalOkHttp() throws Exception {
+        String url = "https://cwms-data.usace.army.mil/cwms-data/";
+        OkHttpClient client = new OkHttpClient.Builder().build();
+        Request request = new Request.Builder().url(url).build();
+        try (Response response = client.newCall(request).execute()) {
+            assertTrue(response.isSuccessful(), "CWMS National URL is not accessible: " + url);
+        }
+    }
+
+    @Test
+    void testNationalJava8() throws Exception {
+        String url = "https://cwms-data.usace.army.mil/cwms-data/";
+        URL obj = new URL(url);
+        HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+        con.setRequestMethod("GET");
+        int responseCode = con.getResponseCode();
+        assertEquals(HttpURLConnection.HTTP_OK, responseCode, "CWMS National URL is not accessible: " + url);
+    }
+
+
+    @Test
+    void testNationalJava11() throws Exception {
+        String url = "https://cwms-data.usace.army.mil/cwms-data/";
+        HttpClient client = HttpClient.newHttpClient();
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .build();
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        int responseCode = response.statusCode();
+        assertEquals(HttpURLConnection.HTTP_OK, responseCode, "CWMS National URL is not accessible: " + url);
+
+    }
+}


### PR DESCRIPTION
uses OkHttp (not cwms-http-client wrapper), vanilla JDK8, vanilla 11 

All tests fail on latest temurin 11.0.20.1 which should have th patch fix for https://bugs.openjdk.org/browse/JDK-8023980 

Tests also fail on Oracle OpenJDK 1.8.0_381