### PR TITLE
fix URL resolve when not ending with slash

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ def versionLabel(gitInfo) {
     def branch = gitInfo.branchName // all branches are snapshots, only tags get released
     def tag = gitInfo.lastTag
     // tag is returned as is. Branch may need cleanup
-    return branch == null ? tag : branch.replace("/","-") + "-SNAPSHOT"
+    return branch == null ? tag : 99 + "." + branch.replace("/","-") + "-SNAPSHOT"
 }
 
 subprojects {

--- a/cwms-http-client/src/main/java/mil/army/usace/hec/cwms/http/client/HttpRequestBuilderImpl.java
+++ b/cwms-http-client/src/main/java/mil/army/usace/hec/cwms/http/client/HttpRequestBuilderImpl.java
@@ -137,9 +137,11 @@ public class HttpRequestBuilderImpl implements HttpRequestBuilder {
 
     //Packaged scope for testing
     Request createRequest() throws IOException {
-        HttpUrl resolve = httpUrl.resolve(endpoint);
-        if (resolve == null) {
-            throw new IOException("Endpoint to API is malformed: " + endpoint);
+        HttpUrl resolve = httpUrl;
+        if (!endpoint.isEmpty()) {
+            resolve = httpUrl.newBuilder()
+                .addPathSegments(endpoint)
+                .build();
         }
         MediaType type = MediaType.parse(mediaType);
         if (type == null) {

--- a/cwms-http-client/src/test/java/mil/army/usace/hec/cwms/http/client/TestApiConnectionInfo.java
+++ b/cwms-http-client/src/test/java/mil/army/usace/hec/cwms/http/client/TestApiConnectionInfo.java
@@ -37,6 +37,7 @@ import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.X509TrustManager;
 import mil.army.usace.hec.cwms.http.client.auth.OAuth2Token;
 import mil.army.usace.hec.cwms.http.client.auth.OAuth2TokenProvider;
+import okhttp3.HttpUrl;
 import org.junit.jupiter.api.Test;
 
 class TestApiConnectionInfo {
@@ -46,6 +47,54 @@ class TestApiConnectionInfo {
         String root = "http://localhost:11524/cwms-data/";
         ApiConnectionInfo apiConnectionInfo = new ApiConnectionInfoBuilder(root).build();
         assertEquals(root, apiConnectionInfo.getApiRoot());
+    }
+
+    @Test
+    void testApiConnectionInfoWithTrailingSlash() throws Exception {
+        String root = "http://localhost:11524/cwms-data/";
+        ApiConnectionInfo apiConnectionInfo = new ApiConnectionInfoBuilder(root).build();
+        HttpRequestBuilderImpl httpRequestBuilder = ((HttpRequestBuilderImpl.HttpRequestExecutorImpl) new HttpRequestBuilderImpl(apiConnectionInfo, "catalog")
+            .get()
+            .withMediaType("application/json"))
+            .getInstance();
+        HttpUrl url = httpRequestBuilder.createRequest().url();
+        assertEquals("http://localhost:11524/cwms-data/catalog", url.url().toString());
+    }
+
+    @Test
+    void testApiConnectionInfoFilename() throws Exception {
+        String root = "http://localhost:11524/cwms-data.txt";
+        ApiConnectionInfo apiConnectionInfo = new ApiConnectionInfoBuilder(root).build();
+        HttpRequestBuilderImpl httpRequestBuilder = ((HttpRequestBuilderImpl.HttpRequestExecutorImpl) new HttpRequestBuilderImpl(apiConnectionInfo)
+            .get()
+            .withMediaType("application/json"))
+            .getInstance();
+        HttpUrl url = httpRequestBuilder.createRequest().url();
+        assertEquals("http://localhost:11524/cwms-data.txt", url.url().toString());
+    }
+
+    @Test
+    void testApiConnectionInfoFilenameEndpoint() throws Exception {
+        String root = "http://localhost:11524/cwms-data";
+        ApiConnectionInfo apiConnectionInfo = new ApiConnectionInfoBuilder(root).build();
+        HttpRequestBuilderImpl httpRequestBuilder = ((HttpRequestBuilderImpl.HttpRequestExecutorImpl) new HttpRequestBuilderImpl(apiConnectionInfo, "data.txt")
+            .get()
+            .withMediaType("application/json"))
+            .getInstance();
+        HttpUrl url = httpRequestBuilder.createRequest().url();
+        assertEquals("http://localhost:11524/cwms-data/data.txt", url.url().toString());
+    }
+
+    @Test
+    void testApiConnectionInfoNoTrailingSlash() throws Exception {
+        String root = "http://localhost:11524/cwms-data";
+        ApiConnectionInfo apiConnectionInfo = new ApiConnectionInfoBuilder(root).build();
+        HttpRequestBuilderImpl httpRequestBuilder = ((HttpRequestBuilderImpl.HttpRequestExecutorImpl) new HttpRequestBuilderImpl(apiConnectionInfo, "catalog")
+            .get()
+            .withMediaType("application/json"))
+            .getInstance();
+        HttpUrl url = httpRequestBuilder.createRequest().url();
+        assertEquals("http://localhost:11524/cwms-data/catalog", url.url().toString());
     }
 
     static SSLSocketFactory getTestSslSocketFactory() {


### PR DESCRIPTION
(cherry picked from commit 2279b44e5105a76dfb400f228c0c19b04e3f8f3e)

Backporting fix from the main branch into a hotfix 4.1.2 branch for a patch release to CWMS 3.3.0