### PR TITLE
Replace cda deprecated query parameters with the current parameter.

### DIFF
--- a/cwms-radar-client/src/main/java/mil/army/usace/hec/cwms/radar/client/controllers/LocationCatalogEndpointInput.java
+++ b/cwms-radar-client/src/main/java/mil/army/usace/hec/cwms/radar/client/controllers/LocationCatalogEndpointInput.java
@@ -34,12 +34,12 @@ import mil.army.usace.hec.cwms.http.client.HttpRequestBuilder;
 public final class LocationCatalogEndpointInput extends EndpointInput {
 
     static final String OFFICE_QUERY_PARAMETER = "office";
-    static final String UNIT_SYSTEM_QUERY_PARAMETER = "unitSystem";
+    static final String UNIT_SYSTEM_QUERY_PARAMETER = "unit-system";
     static final String CURSOR_QUERY_PARAMETER = "cursor";
-    static final String PAGE_SIZE_QUERY_PARAMETER = "pageSize";
+    static final String PAGE_SIZE_QUERY_PARAMETER = "page-size";
     static final String LIKE_QUERY_PARAMETER = "like";
-    static final String CATEGORY_LIKE_QUERY_PARAMETER = "categoryLike";
-    static final String GROUP_LIKE_QUERY_PARAMETER = "groupLike";
+    static final String CATEGORY_LIKE_QUERY_PARAMETER = "location-category-like";
+    static final String GROUP_LIKE_QUERY_PARAMETER = "location-group-like";
 
     private String cursor;
     private Integer pageSize;

--- a/cwms-radar-client/src/main/java/mil/army/usace/hec/cwms/radar/client/controllers/LocationGroupEndpointInput.java
+++ b/cwms-radar-client/src/main/java/mil/army/usace/hec/cwms/radar/client/controllers/LocationGroupEndpointInput.java
@@ -38,7 +38,7 @@ public final class LocationGroupEndpointInput {
     static final String OFFICE_QUERY_PARAMETER = "office";
     static final String GROUP_ID_QUERY_PARAMETER = "group-id";
     static final String CATEGORY_ID_QUERY_PARAMETER = "category-id";
-    static final String INCLUDE_ASSIGNED_QUERY_PARAMETER = "includeAssigned";
+    static final String INCLUDE_ASSIGNED_QUERY_PARAMETER = "include-assigned";
     static final String REPLACE_ASSIGNED_LOCS = "replace-assigned-locs";
 
     public static GetOne getOne(String categoryId, String groupId, String officeId) {

--- a/cwms-radar-client/src/main/java/mil/army/usace/hec/cwms/radar/client/controllers/TimeSeriesCatalogEndpointInput.java
+++ b/cwms-radar-client/src/main/java/mil/army/usace/hec/cwms/radar/client/controllers/TimeSeriesCatalogEndpointInput.java
@@ -34,12 +34,12 @@ import mil.army.usace.hec.cwms.http.client.HttpRequestBuilder;
 public final class TimeSeriesCatalogEndpointInput extends EndpointInput {
 
     static final String OFFICE_QUERY_PARAMETER = "office";
-    static final String UNIT_SYSTEM_QUERY_PARAMETER = "unitSystem";
+    static final String UNIT_SYSTEM_QUERY_PARAMETER = "unit-system";
     static final String CURSOR_QUERY_PARAMETER = "cursor";
-    static final String PAGE_SIZE_QUERY_PARAMETER = "pageSize";
+    static final String PAGE_SIZE_QUERY_PARAMETER = "page-size";
     static final String LIKE_QUERY_PARAMETER = "like";
-    static final String CATEGORY_LIKE_QUERY_PARAMETER = "categoryLike";
-    static final String GROUP_LIKE_QUERY_PARAMETER = "groupLike";
+    static final String CATEGORY_LIKE_QUERY_PARAMETER = "timeseries-category-like";
+    static final String GROUP_LIKE_QUERY_PARAMETER = "timeseries-group-like";
 
     private String cursor;
     private Integer pageSize;

--- a/cwms-radar-client/src/main/java/mil/army/usace/hec/cwms/radar/client/controllers/TimeSeriesEndpointInput.java
+++ b/cwms-radar-client/src/main/java/mil/army/usace/hec/cwms/radar/client/controllers/TimeSeriesEndpointInput.java
@@ -63,7 +63,7 @@ public final class TimeSeriesEndpointInput {
         static final String END_QUERY_PARAMETER = "end";
         static final String TIMEZONE_QUERY_PARAMETER = "timezone";
         static final String PAGE_QUERY_PARAMETER = "page";
-        static final String PAGE_SIZE_QUERY_PARAMETER = "pageSize";
+        static final String PAGE_SIZE_QUERY_PARAMETER = "page-size";
         static final String NAME_QUERY_PARAMETER = "name";
         private final String timeSeriesId;
         private String officeId;


### PR DESCRIPTION
There is a PR on cwms-data-api ( https://github.com/USACE/cwms-data-api/pull/461 ) to remove deprecated query parameters.   This PR changes cwms-data-api-client to use the non-deprecated parameters.  

