### PR TITLE
CWMS-1875 - Parameterized token url in token provider. Removed use of .pem file for loading keystore

### DIFF
--- a/cwbi-auth-http-client/src/main/java/hec/army/usace/hec/cwbi/auth/http/client/trustmanagers/CwbiAuthTrustManager.java
+++ b/cwbi-auth-http-client/src/main/java/hec/army/usace/hec/cwbi/auth/http/client/trustmanagers/CwbiAuthTrustManager.java
@@ -23,14 +23,10 @@
  */
 package hec.army.usace.hec.cwbi.auth.http.client.trustmanagers;
 
-import java.io.IOException;
-import java.io.InputStream;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
-import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
-import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.logging.Level;
@@ -45,6 +41,7 @@ public final class CwbiAuthTrustManager implements X509TrustManager {
 
     private static final Logger LOGGER = Logger.getLogger(CwbiAuthTrustManager.class.getName());
     public static final String TOKEN_URL = "https://auth.corps.cloud/auth/realms/water/protocol/openid-connect/token";
+    public static final String TOKEN_TEST_URL = "https://identity-test.cwbi.us/auth/realms/cwbi/protocol/openid-connect/token";
     private final TrustManagerFactory trustManagerFactory;
 
     private static final X509TrustManager INSTANCE = buildTrustManager();
@@ -60,17 +57,12 @@ public final class CwbiAuthTrustManager implements X509TrustManager {
      */
     private static X509TrustManager buildTrustManager() {
         X509TrustManager retVal = null;
-        try (InputStream trustedCertificateAsInputStream = CwbiAuthTrustManager.class.getResourceAsStream("cwbiAuthServer.pem")) {
-            KeyStore ts = KeyStore.getInstance("JKS");
-            ts.load(null, null);
-            Certificate trustedCertificate = CertificateFactory.getInstance("X.509").generateCertificate(trustedCertificateAsInputStream);
-            ts.setCertificateEntry("cwbi-auth-server-root-certificate", trustedCertificate);
-            ((X509Certificate) trustedCertificate).checkValidity();
+        try {
             TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance("PKIX");
-            trustManagerFactory.init(ts);
+            trustManagerFactory.init((KeyStore) null);
             retVal = new CwbiAuthTrustManager(trustManagerFactory);
-        } catch (CertificateException | NoSuchAlgorithmException | KeyStoreException | IOException e) {
-            LOGGER.log(Level.SEVERE, "Unable to authenticate with CWBI Auth server", e);
+        } catch (NoSuchAlgorithmException | KeyStoreException e) {
+            LOGGER.log(Level.SEVERE, "Unable to initialize CWBI Auth Trust Manager", e);
         }
         return retVal;
     }

--- a/cwbi-auth-http-client/src/test/java/hec/army/usace/hec/cwbi/auth/http/client/TestCwbiAuthTrustManager.java
+++ b/cwbi-auth-http-client/src/test/java/hec/army/usace/hec/cwbi/auth/http/client/TestCwbiAuthTrustManager.java
@@ -51,9 +51,7 @@ final class TestCwbiAuthTrustManager {
         List<String> details = Arrays.asList(acceptedIssuers[0].getIssuerDN().toString().split(","));
         details = details.stream().map(String::trim)
                     .collect(toList());
-        assertTrue(details.contains("CN=ISRG Root X1"));
-        assertTrue(details.contains("O=Internet Security Research Group"));
-        assertTrue(details.contains("C=US"));
+        assertFalse(details.isEmpty());
     }
 
     @Test

--- a/cwbi-auth-http-client/src/test/java/hec/army/usace/hec/cwbi/auth/http/client/TestCwbiAuthUtil.java
+++ b/cwbi-auth-http-client/src/test/java/hec/army/usace/hec/cwbi/auth/http/client/TestCwbiAuthUtil.java
@@ -23,6 +23,7 @@
  */
 package hec.army.usace.hec.cwbi.auth.http.client;
 
+import static hec.army.usace.hec.cwbi.auth.http.client.trustmanagers.CwbiAuthTrustManager.TOKEN_TEST_URL;
 import static hec.army.usace.hec.cwbi.auth.http.client.trustmanagers.CwbiAuthTrustManager.TOKEN_URL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -35,14 +36,14 @@ class TestCwbiAuthUtil {
 
     @Test
     void testBuildTokenProvider() throws IOException {
-        CwbiAuthTokenProvider tokenProvider = (CwbiAuthTokenProvider) CwbiAuthUtil.buildCwbiAuthTokenProvider("cumulus", getTestKeyManager());
+        CwbiAuthTokenProvider tokenProvider = (CwbiAuthTokenProvider) CwbiAuthUtil.buildCwbiAuthTokenProvider(TOKEN_URL, "cumulus", getTestKeyManager());
         assertEquals(TOKEN_URL, tokenProvider.getUrl());
         assertEquals("cumulus", tokenProvider.getClientId());
     }
 
     @Test
     void testNulls() {
-        assertThrows(NullPointerException.class, () -> CwbiAuthUtil.buildCwbiAuthTokenProvider("cumulus", null));
+        assertThrows(NullPointerException.class, () -> CwbiAuthUtil.buildCwbiAuthTokenProvider(TOKEN_TEST_URL, "cumulus", null));
     }
 
     private KeyManager getTestKeyManager() {


### PR DESCRIPTION
Note: An issue was raised against hardcoding the token urls.. that would be addressed in a subsequent pull request, as this ticket called out hardcoding the test url. 