### PR TITLE
by default cwms-http-client should not having caching turned on

### DIFF
--- a/.github/coveragereport/badge_branchcoverage.svg
+++ b/.github/coveragereport/badge_branchcoverage.svg
@@ -101,7 +101,7 @@
         <text x="53" y="15" fill="#010101" fill-opacity=".3">Coverage</text>
         <text x="53" y="14" fill="#fff">Coverage</text>
         
-        <text class="" x="132.5" y="15" fill="#010101" fill-opacity=".3">75.9%</text><text class="" x="132.5" y="14">75.9%</text>
+        <text class="" x="132.5" y="15" fill="#010101" fill-opacity=".3">76.3%</text><text class="" x="132.5" y="14">76.3%</text>
         
     </g>
 

--- a/cwms-http-client/src/main/java/mil/army/usace/hec/cwms/http/client/ApiConnectionInfoBuilder.java
+++ b/cwms-http-client/src/main/java/mil/army/usace/hec/cwms/http/client/ApiConnectionInfoBuilder.java
@@ -45,7 +45,7 @@ public class ApiConnectionInfoBuilder {
     private CookieAuthenticator cookieAuthenticator;
     private SimpleAuthKeyProvider simpleAuthKeyProvider;
     private HostnameVerifier hostnameVerifier;
-    private CacheFactory.CacheSupplier cacheSupplier = CacheFactory.okHttpCacheSupplier();
+    private CacheFactory.CacheSupplier cacheSupplier;
 
     public ApiConnectionInfoBuilder(String apiRoot) {
         this.apiRoot = apiRoot;


### PR DESCRIPTION
application clients need to control the scope of the cache and when to recycle, it should not be enabled by default